### PR TITLE
enable to access built-in func info

### DIFF
--- a/builtin_funcmap.go
+++ b/builtin_funcmap.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	// HACK import internal built-in functions to peek their signatures
+	"reflect"
+
+	_ "text/template"
+	_ "unsafe"
+)
+
+//go:linkname reflectedBuiltinFuncs text/template.builtinFuncs
+func reflectedBuiltinFuncs() map[string]reflect.Value

--- a/funcmap_test.go
+++ b/funcmap_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"text/template"
 )
@@ -44,7 +45,73 @@ func TestSearchFunc(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(fmt.Sprintf(tt.title), func(t *testing.T) {
-			actual := searchFunc(tt.funcMap)(tt.key)
+			actual := searchFunc(tt.funcMap, mockBuiltInFuncMap())(tt.key)
+
+			if len(actual) != len(tt.expected) {
+				t.Fatalf("wrong length. got %d, expected %d", len(actual), len(tt.expected))
+			}
+
+			for i, elem := range actual {
+				if elem != tt.expected[i] {
+					t.Errorf("actual[%d] is wrong. got %s, expected %s",
+						i, elem, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSearchFuncWithBuiltIn(t *testing.T) {
+	tests := []struct {
+		title          string
+		funcMap        template.FuncMap
+		builtInFuncMap map[string]reflect.Value
+		key            string
+		expected       []string
+	}{
+		{
+			"not found",
+			map[string]interface{}{},
+			map[string]reflect.Value{},
+			"",
+			[]string{},
+		},
+		{
+			"one",
+			map[string]interface{}{},
+			map[string]reflect.Value{
+				"myFunc": reflect.ValueOf(func() {}),
+			},
+			"myFunc",
+			[]string{"myFunc"},
+		},
+		{
+			"two",
+			map[string]interface{}{},
+			map[string]reflect.Value{
+				"f1": reflect.ValueOf(func() {}),
+				"f2": reflect.ValueOf(func() {}),
+			},
+			"f",
+			[]string{"f1", "f2"},
+		},
+		{
+			"both",
+			map[string]interface{}{
+				"f1": func() {},
+			},
+			map[string]reflect.Value{
+				"f2": reflect.ValueOf(func() {}),
+			},
+			"f",
+			[]string{"f1", "f2"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf(tt.title), func(t *testing.T) {
+			actual := searchFunc(tt.funcMap, tt.builtInFuncMap)(tt.key)
 
 			if len(actual) != len(tt.expected) {
 				t.Fatalf("wrong length. got %d, expected %d", len(actual), len(tt.expected))
@@ -126,7 +193,7 @@ func TestDocFunc(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(fmt.Sprintf(tt.title), func(t *testing.T) {
-			actual := docFunc(tt.funcMap)(tt.key)
+			actual := docFunc(tt.funcMap, mockBuiltInFuncMap())(tt.key)
 
 			if actual != tt.expected {
 				t.Errorf("wrong output. expected `%s`, got `%s`",
@@ -134,4 +201,51 @@ func TestDocFunc(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDocFuncInBuiltin(t *testing.T) {
+	tests := []struct {
+		title          string
+		funcMap        template.FuncMap
+		builtInFuncMap map[string]reflect.Value
+		key            string
+		expected       string
+	}{
+		{
+			"built-in func",
+			map[string]interface{}{},
+			map[string]reflect.Value{
+				"f": reflect.ValueOf(func() {}),
+			},
+			"f",
+			"f -> ()",
+		},
+		{
+			"search for funcMap first",
+			map[string]interface{}{
+				"f": func(int) {},
+			},
+			map[string]reflect.Value{
+				"f": reflect.ValueOf(func(string) {}),
+			},
+			"f",
+			"f int -> ()",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf(tt.title), func(t *testing.T) {
+			actual := docFunc(tt.funcMap, tt.builtInFuncMap)(tt.key)
+
+			if actual != tt.expected {
+				t.Errorf("wrong output. expected `%s`, got `%s`",
+					tt.expected, actual)
+			}
+		})
+	}
+}
+
+func mockBuiltInFuncMap() map[string]reflect.Value {
+	return map[string]reflect.Value{}
 }


### PR DESCRIPTION
`searchFunc` and `docFunc` can access built-in functions from now on.

```bash
tmpl:1> {{docFunc "len"}}
len reflect.Value -> (int error)
tmpl:2> {{searchFunc "pr"}}
[prepend print printf println]
```
